### PR TITLE
Add Optional "Debug-Mode" to `beatBruteBot.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/desktop.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-**/desktop.ini

--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@ if debug:
 ```
 
 ### Edit `Map.py`
-Lastly, in `Map.py`, add `self.overlap = [str(i) for i in range(10)]` on line 19, right below `self.botPosition = self.checkpoint[:] #bot always starts at the checkpoint` on line 18.
+Lastly, in `Map.py`, add:
+
+```python
+self.overlap = [str(i) for i in range(10)]
+```
+
+on line 19, right below:
+
+```python
+self.botPosition = self.checkpoint[:] #bot always starts at the checkpoint` on line 18.
+```
 
 Then, change the signature of the `moveRobot()` method on line 58, from:
 
@@ -110,7 +120,16 @@ to:
 def moveRobot(self, move, debug=False)
 ```
 
-and change the remaining lines in `moveRobot(self, move, debug=False)` to:
+and change the lines after:
+
+```python
+elif move == 'right':
+	self.botPosition[1] = self.botPosition[1]+1
+	if self.map[self.botPosition[0]][self.botPosition[1]] == '@':
+		self.remainingStains -=1
+```
+
+to the ones below, but make sure to stay within the `moveRobot()` method:
 
 ```python
 self.currentSign = self.map[self.botPosition[0]][self.botPosition[1]]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ def play(self):
 to:
 
 ```python
-def play(self):
+def play(self, debug):
   	...
 		if self.energy<=0:
 			# print("game over, " +botName+  " ran out of energy")
@@ -84,6 +84,48 @@ def play(self):
 		elif self.map.remainingStains<=0:
 			# print(botName + " finished the map with a score of ", self.energy)
 			return self.energy
+```
+
+and add the following lines right under `time.sleep(self.latency)` on line 27:
+
+```python
+if debug:
+	next = input()
+	if next:
+		return 'Next'
+```
+
+### Edit `Map.py`
+Lastly, in `Map.py`, add `self.overlap = [str(i) for i in range(10)]` on line 19, right below `self.botPosition = self.checkpoint[:] #bot always starts at the checkpoint` on line 18.
+
+Then, change the signature of the `moveRobot()` method on line 58, from:
+
+```python
+def moveRobot(self, move)
+```
+
+to:
+
+```python
+def moveRobot(self, move, debug=False)
+```
+
+and change the remaining lines in `moveRobot(self, move, debug=False)` to:
+
+```python
+self.currentSign = self.map[self.botPosition[0]][self.botPosition[1]]
+self.map[self.botPosition[0]][self.botPosition[1]] = 'B'
+if currentPosition == self.checkpoint:
+	self.map[currentPosition[0]][currentPosition[1]] = '1'
+else:
+	if self.currentSign in self.overlap:
+		if self.currentSign == '9' or self.currentSign == 'S':
+			self.overlap.append('S')
+			self.map[currentPosition[0]][currentPosition[1]] = 'S'
+		else:
+			self.map[currentPosition[0]][currentPosition[1]] = self.overlap[self.overlap.index(self.currentSign) + 1]
+	else:
+		self.map[currentPosition[0]][currentPosition[1]] = '1'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Lastly, in `Map.py`, add:
 
 ```python
 self.overlap = [str(i) for i in range(10)]
+self.overlap.append('S')
 ```
 
 on line 19, right below:
@@ -139,7 +140,6 @@ if currentPosition == self.checkpoint:
 else:
 	if self.currentSign in self.overlap:
 		if self.currentSign == '9' or self.currentSign == 'S':
-			self.overlap.append('S')
 			self.map[currentPosition[0]][currentPosition[1]] = 'S'
 		else:
 			self.map[currentPosition[0]][currentPosition[1]] = self.overlap[self.overlap.index(self.currentSign) + 1]


### PR DESCRIPTION
Hey @Celqaz I have edited your automation script so that users have the choice to "debug" maps that their bot is not able to complete. This is done by pressing `ENTER` for each move, so that the user has more control over how they check how their bot behaves. If a user is stuck and is done debugging a certain map, any key can be pressed to start debugging the next map.

Also, every position that the bot has been in is marked with a number, which signifies the number of times the bot has been in that particular cell. This is only done until the number 9, as double-digit numbers would alter the outline of the map. Therefore, if the bot has visited a cell more than nine times, the cell is replaced with an "S", which stands for "Stuck".

Although a minor change, I found that being able to debug my bot following every iteration has helped me a lot. The changes do not force the user to debug, but rather give them a choice so that it is not too intrusive. Would you mind checking the new steps I have added in the Readme.md and letting me know if you are able to reproduce them? Also, let me know if the script works fine with your bot too! If so, I think this would be a nice addition.

For the future, it might be best to just include the new `Game.py` and `Map.py` files instead of having so many additions in the `Readme.md`.